### PR TITLE
test: randomly failed on Windows 

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,9 @@
 //! drop(conn); 
 //! // Dropping `test_db` to check it was really removed
 //! drop(test_db);
-//! assert!(!path.exists()); // Neccessary to test if path war removed
+//! // #9 Problem on windows - tempdir not removed when checked 
+//! std::thread::sleep(std::time::Duration::from_millis(100));
+//! assert!(!path.exists()); // Neccessary to test if path was removed
 //! ```
 //!
 //! # Example with migration

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@
 //! drop(conn); 
 //! // Dropping `test_db` to check it was really removed
 //! drop(test_db);
-//! // #9 Problem on windows - tempdir not removed when checked 
+//! // sleep added due to problem on windows/github actions randomly failed #9
 //! std::thread::sleep(std::time::Duration::from_millis(100));
 //! assert!(!path.exists()); // Neccessary to test if path was removed
 //! ```

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -93,6 +93,9 @@ mod tests {
             println!("Name: {:?}", item);
         }
 
+        // On Windows platform
+        std::thread::sleep(std::time::Duration::from_millis(100));
+
         assert!(!dirpath.exists());
         assert!(!path.exists());
     }

--- a/src/sqlite.rs
+++ b/src/sqlite.rs
@@ -45,22 +45,6 @@ impl TestDb {
 
 }
 
-// impl Drop for TestDb {
-//     fn drop(&mut self) {
-//         // Necesary to drop pool first 
-//         let pool = self.pool.take();
-//         drop(pool);
-//         // self.pool = None;
-//         // drop(&self.pool);
-//         // Have to remove file before temp_dir goes out of scope
-//         // @see https://docs.rs/tempfile/3.1.0/tempfile/struct.TempDir.html#resource-leaking
-//         std::fs::remove_file(&self.db_path)
-//             .expect(format!("Not possible to remove self.db_path: {:?}", self.db_path).as_str());
-//     }
-// }
-
-
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -93,7 +77,7 @@ mod tests {
             println!("Name: {:?}", item);
         }
 
-        // On Windows platform
+        // On Windows/GitHub Actions problem with failing #9
         std::thread::sleep(std::time::Duration::from_millis(100));
 
         assert!(!dirpath.exists());


### PR DESCRIPTION
fixes #9 

Problem on Windows solved using `std::thread::Sleep`
Probably problem that some caching was involved. Do not know exactly.